### PR TITLE
Auto-generate props if there are more than 1 arguments or the one provided does not end in `Props`

### DIFF
--- a/rscx-macros/src/lib.rs
+++ b/rscx-macros/src/lib.rs
@@ -450,7 +450,10 @@ impl ToTokens for ComponentFn {
                             panic!("receiver arguments unsupported");
                         }
                         FnArg::Typed(mut t) => {
-                            t.attrs.push(parse_quote! { #[builder(setter(into))] });
+                            if t.attrs.is_empty() {
+                                t.attrs.push(parse_quote! { #[builder(setter(into))] });
+                            }
+
                             t
                         }
                     })

--- a/rscx/examples/autogenerated_props.rs
+++ b/rscx/examples/autogenerated_props.rs
@@ -1,0 +1,38 @@
+use rscx::{component, html};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app = app().await;
+    println!("{}", app);
+    Ok(())
+}
+
+// simple function returning a String
+async fn app() -> String {
+    let s = "ul { color: red; }";
+    html! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <style>{s}</style>
+            </head>
+            <body>
+                // call a component with props and children
+                <Section title="Hello">
+                    <p>"I am a paragraph"</p>
+                </Section>
+            </body>
+        </html>
+    }
+}
+
+#[component]
+/// mark functions with #[component] to use them as components inside html! macro
+fn Section(title: String, children: String) -> String {
+    html! {
+        <div>
+            <h1>{ title }</h1>
+            { children }
+        </div>
+    }
+}


### PR DESCRIPTION
This is a bit opinionated because it always applies the `#[builder(setter(into))]` attribute but this makes usage a lot more ergonomic. It does carry over all attributes so users can customize it if they want.

Resolves: #1.