### PR TITLE
Implement reference props

### DIFF
--- a/rscx-macros/src/lib.rs
+++ b/rscx-macros/src/lib.rs
@@ -9,7 +9,7 @@ use rstml::{
     Parser, ParserConfig,
 };
 use syn::punctuated::Punctuated;
-use syn::{parse::Parse, parse_quote, spanned::Spanned, Expr, ExprLit, FnArg, ItemStruct, Token};
+use syn::{parse::Parse, parse_quote, spanned::Spanned, Expr, ExprLit, FnArg, ItemStruct, Token, Type, Lifetime};
 
 #[proc_macro]
 pub fn html(tokens: TokenStream) -> TokenStream {
@@ -379,8 +379,8 @@ impl ToTokens for PropsStruct {
             #[builder(doc, crate_module_path=::rscx::typed_builder)]
             #item
 
-            impl ::rscx::props::Props for #name {
-                type Builder = #builder_name;
+            impl<'a> ::rscx::props::Props for #name<'a> {
+                type Builder = #builder_name<'a>;
                 fn builder() -> Self::Builder {
                     #name::builder()
                 }
@@ -457,6 +457,12 @@ impl ToTokens for ComponentFn {
                             panic!("receiver arguments unsupported");
                         }
                         FnArg::Typed(mut t) => {
+                            if let Type::Reference(ty_ref) = t.ty.as_mut() {
+                                if ty_ref.lifetime.is_none() {
+                                    ty_ref.lifetime = Some(Lifetime::new("'a", ty_ref.span()));
+                                }
+                            }
+
                             if t.attrs.is_empty() {
                                 t.attrs.push(parse_quote! { #[builder(setter(into))] });
                             }
@@ -482,11 +488,13 @@ impl ToTokens for ComponentFn {
                 (
                     quote! {
                         #[rscx::props]
-                        pub struct #props_name {
-                            #field_defs
+                        pub struct #props_name<'a> {
+                            #field_defs,
+                            #[builder(default)]
+                            phantom: std::marker::PhantomData<&'a ()>
                         }
                     },
-                    quote! { #props_name { #field_names }: #props_name },
+                    quote! { #props_name { #field_names, .. }: #props_name<'a> },
                 )
             }
         };
@@ -498,7 +506,7 @@ impl ToTokens for ComponentFn {
         tokens.extend(quote! {
             #defs
             #[allow(non_snake_case)]
-            #vis async fn #name(#args) #output {
+            #vis async fn #name<'a>(#args) #output {
                 #body
             }
         });

--- a/rscx/examples/reference_props.rs
+++ b/rscx/examples/reference_props.rs
@@ -1,0 +1,38 @@
+use rscx::{component, html};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app = app().await;
+    println!("{}", app);
+    Ok(())
+}
+
+// simple function returning a String
+async fn app() -> String {
+    let s = "ul { color: red; }";
+    html! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <style>{s}</style>
+            </head>
+            <body>
+                // call a component with props and children
+                <Section title="Hello">
+                    <p>"I am a paragraph"</p>
+                </Section>
+            </body>
+        </html>
+    }
+}
+
+#[component]
+/// mark functions with #[component] to use them as components inside html! macro
+fn Section(title: &str, children: String) -> String {
+    html! {
+        <div>
+            <h1>{ title }</h1>
+            { children }
+        </div>
+    }
+}


### PR DESCRIPTION
This patch allows users to declare parameters as references if they are using the auto-generated props. These parameters would normally need a lifetime but we simply tack one on automatically if it doesn't already have one!